### PR TITLE
Update actions node version to 20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
           version: latest
           kubectl-install: true
           kubectl-version: ${{ matrix.kubectl-version }}
-      - run: kubectl version --client --short
+      - run: kubectl version --client
       
   # Auto Approve passing Dependabot Patch & Minor PRs
   auto-approve-dependabot:

--- a/action.yml
+++ b/action.yml
@@ -15,5 +15,5 @@ inputs:
     required: false
     default: 'latest'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Addressing this warning:
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: loft-sh/setup-devspace@main. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
